### PR TITLE
Wordpress 4.3.1 compatibility

### DIFF
--- a/aa-tei-xml/aa-tei-xml.php
+++ b/aa-tei-xml/aa-tei-xml.php
@@ -68,12 +68,13 @@ add_filter( 'wp_mime_type_icon', 'aa_xml_mime_type_icon', 10, 3 );
 
 function aa_add_xml_mime($mimes) {
   $mimes['xml'] = 'application/xml';
-  $mimes['xsl'] = 'application/xsl';
-  // $mimes['xslt'] = 'application/xml';
+  $mimes['tei'] = 'application/tei+xml'; // http://www.iana.org/assignments/media-types/application/tei+xml
+  $mimes['xsl'] = 'application/xslt+xml';     // http://www.iana.org/assignments/media-types/media-types.xhtml, http://www.w3.org/TR/2007/REC-xslt20-20070123/#media-type-registration
+  $mimes['xslt'] = 'application/xslt+xml';
   return $mimes;
 }
 function aa_xml_mime_type_icon($icon, $mime, $post_id) {
-	if ( $mime == 'application/xml' || $mime == 'text/xml' )
+	if ( $mime == 'application/xml' || $mime == 'text/xml'  || $mime == 'application/tei+xml' )
 		return wp_mime_type_icon('document');
 	return $icon;
 }

--- a/aa-tei-xml/inc/class-aa-tei-xml.php
+++ b/aa-tei-xml/inc/class-aa-tei-xml.php
@@ -181,7 +181,7 @@ class AATEIXML{
 
 		$file = get_post_meta( $xml_ID, '_wp_attached_file', true);
 		
-		$teiFile = get_option('upload_path') .'/'. $file;
+		$teiFile = get_attached_file($xml_ID);
 		
 		// does the file exist?
 		if ( !file_exists( $teiFile ) ){
@@ -200,13 +200,13 @@ class AATEIXML{
 
 	protected function get_xsl_file( $post_ID )
 	{
-		$xslt_ID 	= get_post_meta( $post_ID, 'aa_tei_xsl', true);
+		$xsl_ID 	= get_post_meta( $post_ID, 'aa_tei_xsl', true);
 
 		// If there's a document-specific XSLT set...
-		if ( isset( $xslt_ID ) && is_numeric( is_int($xslt_ID ))) {
+		if ( isset( $xsl_ID ) && is_numeric( is_int($xsl_ID ))) {
 			// if it's an int, it's an attachment ID.
-			$stylesheet = get_post_meta( $xslt_ID, '_wp_attached_file', true);
-			$stylesheet = get_option('upload_path') . '/' . $xslt;
+			//$stylesheet = get_post_meta( $xsl_ID, '_wp_attached_file', true);
+			$stylesheet = get_attached_file($xsl_ID);
 		 
 		} else {
 			$stylesheet = AATEIXML_PATH . "xsl/default.xsl";
@@ -283,10 +283,12 @@ class AATEIXML{
 		$content = sprintf($set_thumbnail_link, esc_html( 'Set XML document' ));
 
 		$file = get_post_meta( $xml_ID, '_wp_attached_file', true);
-		$abspath = get_option('upload_path') . '/' . $file;
-		if ( $file && file_exists( $abspath ) )
+		$abspath = get_attached_file($xml_ID);
+		if ( $file && file_exists( $abspath ) ) {
 			$content .= '<p><img src="' . admin_url('images/yes.png') . '" alt="XML document specified"/> XML document specified: <a href="' . esc_html( wp_get_attachment_url( $xml_ID ) ) . '">' . esc_html( get_the_title($xml_ID) ) . '</a></p>';
-
+    } else {
+			$content .= '<p><img src="' . admin_url('images/no.png') . '" alt="XML document NOT specified"/> XML document NOT specified: ' . esc_html( get_the_title($xml_ID) ) . '</p>';
+    }
 		$content .= '</div> <!-- #xml-file-holder -->';
 		return $content;
 	}
@@ -305,7 +307,7 @@ class AATEIXML{
 		$content .= '<span>[Optional: Default xsl file will be used if none is submitted]</span>';
 
 		$file = get_post_meta( $xsl_ID, '_wp_attached_file', true);
-		$abspath = get_option('upload_path') . '/' . $file;
+		$abspath = get_attached_file($xsl_ID);
 		if ( $file && file_exists( $abspath ) )
 			$content .= '<p><img src="' . admin_url('images/yes.png') . '" alt="XSLT document specified"/>XSLT document specified: <a href="' . esc_html( wp_get_attachment_url( $xsl_ID ) ) . '">' . esc_html( get_the_title($xsl_ID) ) . '</a></p>';
 


### PR DESCRIPTION
After this changes I have possibility to select an XML and, optionally, XSLT files and replace post content to converted TEI-content.
